### PR TITLE
Switch to Bootstrap CSS Only

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "moment": "^2.20.1"
   },
   "peerDependencies": {
-    "bootstrap": "^3.3.7",
+    "bootstrap-css-only": "^3.3.7",
     "react": "v16.2.0",
     "react-bootstrap": "^0.31.3",
     "react-datetime": "2.14.0",
@@ -41,7 +41,6 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-react-hmre": "^1.1.1",
     "babel-preset-stage-0": "^6.24.1",
-    "bootstrap": "^3.3.7",
     "cross-env": "^5.0.5",
     "css-loader": "^0.28.4",
     "enzyme": "3.3.0",

--- a/src/CheckBoxField.jsx
+++ b/src/CheckBoxField.jsx
@@ -14,8 +14,6 @@ import Label from 'Label';
 
 import validationMessage from 'utils';
 
-import 'bootstrap/dist/css/bootstrap.css';
-
 const propTypes = {
   /** Field label. */
   label: PropTypes.string.isRequired,

--- a/src/DateTimeField.jsx
+++ b/src/DateTimeField.jsx
@@ -12,7 +12,6 @@ import moment from 'moment';
 import Label from 'Label';
 import validationMessage from 'utils';
 
-import 'bootstrap/dist/css/bootstrap.css';
 import 'react-datetime/css/react-datetime.css';
 
 const propTypes = {

--- a/src/FieldSet.jsx
+++ b/src/FieldSet.jsx
@@ -1,8 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import 'bootstrap/dist/css/bootstrap.css';
-
 const propTypes = {
   /** Fieldset label. */
   label: PropTypes.string.isRequired,

--- a/src/Label.jsx
+++ b/src/Label.jsx
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 
 import { ControlLabel, Glyphicon } from 'react-bootstrap';
 
-import 'bootstrap/dist/css/bootstrap.css';
-
 const Label = ({ label, required }) => {
   if (label && required) {
     return (<ControlLabel>{label}&nbsp;<small><Glyphicon glyph="asterisk" style={{ color: '#a94442' }} /></small></ControlLabel>);

--- a/src/RadioField.jsx
+++ b/src/RadioField.jsx
@@ -11,8 +11,6 @@ import {
 import Label from 'Label';
 import validationMessage from 'utils';
 
-import 'bootstrap/dist/css/bootstrap.css';
-
 const propTypes = {
   /** Field label. */
   label: PropTypes.string.isRequired,

--- a/src/SelectField.jsx
+++ b/src/SelectField.jsx
@@ -9,7 +9,6 @@ import Select from 'react-select';
 import Label from 'Label';
 import validationMessage from 'utils';
 
-import 'bootstrap/dist/css/bootstrap.css';
 import 'react-select/dist/react-select.css';
 import './selectFieldStyle.css';
 

--- a/src/TextField.jsx
+++ b/src/TextField.jsx
@@ -14,8 +14,6 @@ import Label from 'Label';
 
 import validationMessage from 'utils';
 
-import 'bootstrap/dist/css/bootstrap.css';
-
 const propTypes = {
   /** additional Props that can be passed to Form Control */
   ...FormControl.propTypes,

--- a/src/ToggleField.jsx
+++ b/src/ToggleField.jsx
@@ -11,7 +11,6 @@ import Toggle from 'react-toggle';
 import Label from 'Label';
 import validationMessage from 'utils';
 
-import 'bootstrap/dist/css/bootstrap.css';
 import 'react-toggle/style.css';
 
 const propTypes = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1785,9 +1785,10 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-bootstrap@^3.3.7:
+bootstrap-css-only@^3.3.7:
   version "3.3.7"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.3.7.tgz#5a389394549f23330875a3b150656574f8a9eb71"
+  resolved "https://registry.yarnpkg.com/bootstrap-css-only/-/bootstrap-css-only-3.3.7.tgz#68a15925aa7b9b0fc0feb73ff85d8b8c3989c16d"
+  integrity sha1-aKFZJap7mw/A/rc/+F2LjDmJwW0=
 
 bowser@^1.0.0, bowser@^1.7.3:
   version "1.9.3"


### PR DESCRIPTION
This change remove all Bootstrap javascript dependencies in favor of
react-bootstrap implementations to work around the issue with XSS and
scrollspy, which this package does not use anyway.

More info on vulnerability:
https://nvd.nist.gov/vuln/detail/CVE-2018-14041

Bootstrap CSS Only:
https://www.npmjs.com/package/bootstrap-css-only